### PR TITLE
feat: block LLM providers when not authenticated

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Provider::Anthropic => {
             let auth = AuthStorage::new()?;
-            Box::new(AnthropicThinker::new(cli.model, auth))
+            Box::new(AnthropicThinker::new(cli.model, auth)?)
         }
     };
 

--- a/src/thinker/anthropic.rs
+++ b/src/thinker/anthropic.rs
@@ -24,11 +24,20 @@ pub struct AnthropicThinker {
 }
 
 impl AnthropicThinker {
-    pub fn new(model: Option<String>, auth: AuthStorage) -> Self {
-        Self {
+    pub fn new(model: Option<String>, auth: AuthStorage) -> Result<Self> {
+        let has_cred = auth.get("anthropic")?.is_some()
+            || std::env::var("ANTHROPIC_API_KEY")
+                .map(|k| !k.is_empty())
+                .unwrap_or(false);
+        if !has_cred {
+            bail!(
+                "not authenticated for Anthropic\n\n  Run:  golem login\n  Or:   export ANTHROPIC_API_KEY=sk-ant-..."
+            );
+        }
+        Ok(Self {
             model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
             auth,
-        }
+        })
     }
 
     fn build_messages(context: &Context) -> Vec<Message> {


### PR DESCRIPTION
Checks for credentials at startup before constructing the thinker. If no OAuth token or API key is found, exits with a clear message:

```
error: not authenticated for Anthropic

  Run:  golem login
  Or:   export ANTHROPIC_API_KEY=sk-ant-...
```

Human and mock providers work without auth. LLM providers fail fast instead of crashing deep in an API call.

Closes #15