### PR TITLE
feat: add thinking spinner during LLM calls

### DIFF
--- a/src/engine/react.rs
+++ b/src/engine/react.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 use super::Engine;
 use crate::consts::DEFAULT_SESSION_HISTORY_LIMIT;
 use crate::memory::{Memory, MemoryEntry};
+use crate::spinner::Spinner;
 use crate::thinker::{Context, Step, Thinker, TokenUsage};
 use crate::tools::{Outcome, ToolRegistry, ToolResult};
 
@@ -122,8 +123,11 @@ impl Engine for ReactEngine {
             };
 
             let step_result = {
+                let spinner = Spinner::start("thinking...");
                 let thinker = self.thinker.read().await;
-                thinker.next_step(&context).await?
+                let result = thinker.next_step(&context).await;
+                spinner.stop().await;
+                result?
             };
 
             if let Some(usage) = step_result.usage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod engine;
 pub mod events;
 pub mod memory;
 pub mod prompts;
+pub mod spinner;
 pub mod thinker;
 pub mod tools;

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -1,0 +1,92 @@
+//! A minimal terminal spinner for visual feedback during async operations.
+
+use std::io::Write;
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+
+/// Braille spinner frames.
+const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Frame interval.
+const INTERVAL: Duration = Duration::from_millis(80);
+
+/// A terminal spinner that runs in a background task.
+///
+/// Call [`Spinner::start`] to begin, then [`Spinner::stop`] when done.
+/// The spinner writes to stderr so it doesn't interfere with stdout output.
+pub struct Spinner {
+    handle: JoinHandle<()>,
+    cancel: tokio::sync::watch::Sender<bool>,
+}
+
+impl Spinner {
+    /// Start a spinner with the given message (e.g. `"thinking"`).
+    pub fn start(message: &str) -> Self {
+        let (cancel_tx, mut cancel_rx) = tokio::sync::watch::channel(false);
+        let message = message.to_string();
+
+        let handle = tokio::spawn(async move {
+            let mut i = 0;
+            loop {
+                let frame = FRAMES[i % FRAMES.len()];
+                // \r moves to start of line, \x1b[2K clears the line
+                eprint!("\x1b[2K\r{frame} {message}");
+                let _ = std::io::stderr().flush();
+
+                tokio::select! {
+                    _ = tokio::time::sleep(INTERVAL) => {}
+                    _ = cancel_rx.changed() => break,
+                }
+                i += 1;
+            }
+            // Clear the spinner line
+            eprint!("\x1b[2K\r");
+            let _ = std::io::stderr().flush();
+        });
+
+        Self {
+            handle,
+            cancel: cancel_tx,
+        }
+    }
+
+    /// Stop the spinner and clear its line.
+    pub async fn stop(self) {
+        let _ = self.cancel.send(true);
+        let _ = self.handle.await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frames_are_non_empty() {
+        assert!(!FRAMES.is_empty());
+        for frame in FRAMES {
+            assert!(!frame.is_empty());
+        }
+    }
+
+    #[test]
+    fn frames_are_single_braille_chars() {
+        for frame in FRAMES {
+            assert_eq!(frame.chars().count(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn spinner_starts_and_stops_without_panic() {
+        let spinner = Spinner::start("testing");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        spinner.stop().await;
+    }
+
+    #[tokio::test]
+    async fn spinner_immediate_stop() {
+        let spinner = Spinner::start("quick");
+        spinner.stop().await;
+    }
+}


### PR DESCRIPTION
## Problem

The terminal hangs silently while waiting for the LLM response — no visual feedback that anything is happening.

## Solution

A braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) on stderr during `thinker.next_step()`:

```
⠹ thinking...
```

Clears itself when the response arrives, before printing the thought/action.

## Implementation

`src/spinner.rs` — minimal spinner using a tokio background task:
- `Spinner::start(msg)` spawns a task that cycles braille frames at 80ms
- `Spinner::stop()` sends cancel via `watch` channel, awaits cleanup
- Writes to stderr (doesn't interfere with stdout capture)
- Clears its line on stop (`\x1b[2K\r`)

`src/engine/react.rs` — wraps `thinker.next_step()`:
```rust
let spinner = Spinner::start("thinking...");
let result = thinker.next_step(&context).await;
spinner.stop().await;
```

## Tests

179 total (4 new):
- Braille frames are non-empty single characters
- Start/stop lifecycle works
- Immediate stop (no delay) works