### PR TITLE
fix: session memory prompt — tell LLM to use prior task context

### DIFF
--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -1,3 +1,4 @@
 pub mod react;
 
 pub use react::build_react_system_prompt;
+pub use react::build_react_system_prompt_with_session;

--- a/src/prompts/react.rs
+++ b/src/prompts/react.rs
@@ -19,6 +19,8 @@ const ANSWER_FORMAT: &str = r#"{
   "answer": "your final answer to the task"
 }"#;
 
+const SESSION_CONTEXT: &str = "Earlier messages may contain prior tasks and answers from this session. Use that context — if a previous task already produced the information needed, reference it directly instead of re-running tools.";
+
 const RULES: &[&str] = &[
     "Your ENTIRE response must be a single JSON object. Never include text before or after the JSON.",
     "No markdown fences, no extra text, no extra keys.",
@@ -33,10 +35,23 @@ const RULES: &[&str] = &[
 ];
 
 pub fn build_react_system_prompt(tools: &[ToolDescription]) -> String {
+    build_react_system_prompt_with_session(tools, false)
+}
+
+pub fn build_react_system_prompt_with_session(
+    tools: &[ToolDescription],
+    has_session_history: bool,
+) -> String {
     let mut prompt = String::with_capacity(1024);
 
     prompt.push_str(INTRO);
     prompt.push('\n');
+
+    if has_session_history {
+        prompt.push('\n');
+        prompt.push_str(SESSION_CONTEXT);
+        prompt.push('\n');
+    }
 
     // Tool list
     if !tools.is_empty() {
@@ -151,5 +166,25 @@ mod tests {
         assert!(prompt.contains("CRITICAL"));
         assert!(prompt.contains("entire response must be a single JSON object"));
         assert!(prompt.contains("inside the \"thought\" field"));
+    }
+
+    #[test]
+    fn no_session_context_without_history() {
+        let prompt = build_react_system_prompt_with_session(&[], false);
+        assert!(!prompt.contains("prior tasks"));
+        assert!(!prompt.contains("re-running tools"));
+    }
+
+    #[test]
+    fn includes_session_context_with_history() {
+        let prompt = build_react_system_prompt_with_session(&[], true);
+        assert!(prompt.contains("prior tasks"));
+        assert!(prompt.contains("re-running tools"));
+    }
+
+    #[test]
+    fn default_prompt_has_no_session_context() {
+        let prompt = build_react_system_prompt(&[]);
+        assert!(!prompt.contains("prior tasks"));
     }
 }


### PR DESCRIPTION
## Problem

Session history was being sent as messages but the system prompt said nothing about it. The LLM re-ran tools for information it already had:

```
golem> list all files in this folder
=> The current folder is empty...

golem> how many files are in this folder?
[iteration 1] Executing: ls -la     ← re-runs the same command!
=> There are 0 files.
```

## Root cause

Two issues:
1. **System prompt** had zero mentions of session context — the LLM didn't know prior messages were relevant
2. **Message format** — prior tasks looked identical to the current task (`Task: ...`) so nothing distinguished them

## Fix

**System prompt** — when session history exists, inject:
> *Earlier messages may contain prior tasks and answers from this session. Use that context — if a previous task already produced the information needed, reference it directly instead of re-running tools.*

**Message tagging** — prior tasks now show as:
```
[Prior task 1/2] list all files in this folder
```
instead of bare `Task: ...`

## Expected behavior after fix

```
golem> list all files in this folder
=> The current folder is empty...

golem> how many files are in this folder?
[done] There are 0 files.     ← answers from session context, no tool call
```

## Tests

182 total (3 new):
- Session context present/absent based on flag
- Default prompt has no session context