### PR TITLE
docs: add privacy policy and terms of service

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,56 @@
+# Privacy Policy
+
+**Last updated:** March 2, 2026
+
+Golem is an open-source CLI tool that connects to third-party AI providers (Anthropic, Google, etc.) on your behalf. This policy explains what data Golem handles and how.
+
+## What Golem collects
+
+**Nothing.** Golem does not collect, transmit, or store any data on external servers operated by the Golem project. There is no telemetry, analytics, or crash reporting.
+
+## Data stored locally
+
+Golem stores the following on your machine in a SQLite database (typically `~/.local/share/golem/golem.db`):
+
+- **OAuth tokens** — access and refresh tokens for providers you log into. These are stored locally and never sent anywhere except back to the issuing provider.
+- **Session memory** — task history and conversation context from your REPL sessions.
+- **Configuration** — your model preferences and settings.
+
+You can delete all local data by removing the database file.
+
+## Data sent to third-party providers
+
+When you use Golem, your prompts and conversation context are sent directly to the AI provider you selected (e.g., Anthropic, Google). These requests go straight from your machine to the provider's API — Golem does not proxy, intercept, or log them.
+
+Each provider has its own privacy policy:
+
+- [Anthropic Privacy Policy](https://www.anthropic.com/privacy)
+- [Google AI Privacy Policy](https://ai.google.dev/terms)
+
+**You are responsible for reviewing and accepting each provider's terms before using them through Golem.**
+
+## OAuth authentication
+
+Golem uses the OAuth 2.0 authorization code flow with PKCE to authenticate with providers. During login:
+
+1. Your browser opens the provider's consent page — Golem never sees your password.
+2. You approve access and paste an authorization code back into Golem.
+3. Golem exchanges the code for tokens and stores them locally.
+
+No credentials pass through any Golem-operated server.
+
+## Open source
+
+Golem's source code is publicly available at [github.com/assapir/golem](https://github.com/assapir/golem). You can audit exactly what the software does.
+
+## Children's privacy
+
+Golem is not directed at children under 13 and does not knowingly collect data from children.
+
+## Changes to this policy
+
+Updates will be posted to this file in the repository. The "last updated" date at the top will reflect the most recent revision.
+
+## Contact
+
+For questions about this policy, open an issue at [github.com/assapir/golem/issues](https://github.com/assapir/golem/issues) or email [assaf@sapir.io](mailto:assaf@sapir.io).

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,54 @@
+# Terms of Service
+
+**Last updated:** March 2, 2026
+
+## Acceptance
+
+By using Golem, you agree to these terms. If you don't agree, don't use it.
+
+## What Golem is
+
+Golem is an open-source command-line tool that acts as a client for third-party AI providers. It runs entirely on your machine.
+
+## Your responsibilities
+
+- **API provider terms.** You must comply with the terms of service of any AI provider you access through Golem (Anthropic, Google, etc.). Golem is just a client — the provider relationship is between you and them.
+- **Authentication credentials.** You are responsible for keeping your OAuth tokens and API keys secure. Don't share your database file.
+- **Shell commands.** Golem can execute shell commands on your system when directed by the AI. You are responsible for reviewing what it runs, especially in read-write mode.
+- **Content.** You are responsible for the prompts you send and how you use the AI's responses.
+
+## No warranty
+
+Golem is provided **"as is"**, without warranty of any kind, express or implied. This includes but is not limited to warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+The authors are not responsible for:
+
+- Actions taken by AI providers in response to your prompts
+- Shell commands executed by the tool
+- Data loss, system damage, or security issues arising from use
+- Accuracy or reliability of AI-generated responses
+- Service availability or API changes by third-party providers
+
+## Limitation of liability
+
+To the maximum extent permitted by law, the authors of Golem shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of the software.
+
+## Open source license
+
+Golem is licensed under the [GNU General Public License v3.0](https://github.com/assapir/golem/blob/main/LICENSE). These terms of service apply to the hosted/distributed version and do not limit your rights under the GPL.
+
+## Third-party services
+
+Golem connects to third-party APIs. We have no control over their availability, pricing, terms, or data practices. Your use of those services is governed by their respective agreements.
+
+## Termination
+
+You can stop using Golem at any time by uninstalling it and deleting your local database. There are no accounts to close.
+
+## Changes
+
+We may update these terms by committing changes to this file. Continued use after changes constitutes acceptance.
+
+## Contact
+
+For questions, open an issue at [github.com/assapir/golem/issues](https://github.com/assapir/golem/issues) or email [assaf@sapir.io](mailto:assaf@sapir.io).


### PR DESCRIPTION
Required for Google OAuth consent screen verification.

Adds:
- **PRIVACY.md** — explains Golem collects nothing, stores tokens/config locally only, sends prompts directly to providers
- **TERMS.md** — as-is disclaimer, user responsibility for provider terms and shell commands

Links for Google consent screen:
- Privacy: `https://github.com/assapir/golem/blob/main/PRIVACY.md`
- Terms: `https://github.com/assapir/golem/blob/main/TERMS.md`