### PR TITLE
feat: add Google Gemini provider with OAuth support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ cargo fmt                      # CI enforces cargo fmt --check
 | Prompts | `src/prompts/react.rs` |
 | Constants | `src/consts.rs` |
 | Banner | `src/banner.rs` |
+| Provider wiring | `src/provider.rs` |
 
 ## Code style
 
@@ -38,40 +39,59 @@ cargo fmt                      # CI enforces cargo fmt --check
 - Use `env!("CARGO_PKG_VERSION")` and `env!("CARGO_PKG_*")` — never hardcode metadata.
 - `main.rs` imports from the library crate (`use golem::...`), not `mod` declarations.
 - Project constants go in `src/consts.rs`, display logic in `src/banner.rs`.
+- Default model constants belong in the thinker module that uses them, not in `consts.rs`.
 
 ## Module layout
 
 ```
 src/
-├── main.rs              # CLI, wiring, REPL
+├── main.rs              # CLI parsing + REPL loop (no provider logic)
 ├── lib.rs               # re-exports
+├── provider.rs          # ProviderConfig trait, provider impls, build/login/logout
 ├── banner.rs            # startup banner + session summary
 ├── commands/            # Command trait + CommandRegistry + built-in /slash commands
 ├── config/              # SQLite key-value config (model preference, etc.)
 ├── consts.rs            # project-wide constants (from Cargo.toml metadata)
-├── auth/                # OAuth PKCE flow + credential storage (SQLite)
+├── auth/                # OAuth PKCE flows + credential storage (SQLite)
+│   ├── mod.rs           # login/logout routing
+│   ├── oauth.rs         # Anthropic OAuth PKCE
+│   ├── google_oauth.rs  # Google OAuth PKCE (loopback redirect)
+│   └── storage.rs       # AuthStorage (SQLite credentials table)
 ├── engine/              # Engine trait + ReactEngine (ReAct loop)
 ├── events.rs            # EventBus (tokio broadcast) for decoupled communication
 ├── prompts/             # shared ReAct system prompt builder
-├── thinker/             # Thinker trait + providers (anthropic, human, mock)
+├── thinker/             # Thinker trait + providers
+│   ├── mod.rs           # Thinker trait, Step, parse_response
+│   ├── anthropic.rs     # Anthropic Messages API
+│   ├── gemini.rs        # Google Gemini generateContent API
+│   ├── human.rs         # Human-in-the-loop thinker
+│   └── mock.rs          # MockThinker for tests
 ├── tools/               # Tool trait + ToolRegistry + ShellTool
-└── memory/              # Memory trait + SqliteMemory (task + session memory)
+├── memory/              # Memory trait + SqliteMemory (task + session memory)
+└── spinner.rs           # Thinking spinner during LLM calls
 ```
+
+## Adding a new provider
+
+1. Create `src/thinker/my_provider.rs`, implement `Thinker` trait:
+   - Use `build_react_system_prompt()` from `src/prompts/react.rs` — don't duplicate.
+   - Return `StepResult { step, usage: Option<TokenUsage> }` from `next_step()`.
+   - Implement `models()`, `model()`, `set_model()` for model selection support.
+   - Own the default model as a `const` in the module.
+2. If the provider needs OAuth, create `src/auth/my_oauth.rs` with the flow.
+3. In `src/provider.rs`:
+   - Add a module implementing `ProviderConfig` (5 methods: `id`, `display_name`, `env_var`, `build_thinker`, `login`).
+   - Add variants to `Provider` and `LoginProvider` enums.
+   - Add a match arm in `Provider::config()`, `LoginProvider::config()`, and `provider_config_by_id()`.
+4. Register the thinker module in `src/thinker/mod.rs`.
+5. Add the provider to `SUPPORTED_PROVIDERS` in `src/auth/mod.rs` if it has OAuth.
+6. Test with `MockThinker` in `tests/react_test.rs`.
 
 ## Adding a new tool
 
 1. Create `src/tools/my_tool.rs`, implement `Tool` trait (`Send + Sync + async`).
 2. Register in `main.rs`: `tools.register(Arc::new(MyTool)).await;`
 3. Add tests in `tests/tools_test.rs`.
-
-## Adding a new provider
-
-1. Create `src/thinker/my_provider.rs`, implement `Thinker` trait.
-2. Use `build_react_system_prompt()` from `src/prompts/react.rs` — don't duplicate.
-3. Return `StepResult { step, usage: Option<TokenUsage> }` from `next_step()`.
-4. Implement `models()`, `model()`, `set_model()` for model selection support.
-5. Add `Provider` enum variant + match arm in `main.rs`.
-6. Test with `MockThinker` in `tests/react_test.rs`.
 
 ## Adding a new command
 
@@ -82,6 +102,7 @@ src/
 
 ## Key abstractions
 
+- **`ProviderConfig`** — trait defining a provider's identity, auth, and thinker construction. Each provider (Anthropic, Google) implements it. The `Provider` and `LoginProvider` CLI enums dispatch to implementations via `config()`.
 - **`StateChange`** — enum for REPL state updates (`Auth`, `Model`). Commands return `CommandResult::StateChanged(StateChange::*)` and the REPL applies the change.
 - **`EventBus`** — `tokio::sync::broadcast` channel for decoupled notifications. Components subscribe via `bus.subscribe()`.
 - **`SessionEntry`** — task + answer summary persisted across tasks. Loaded into `Context.session_history` so the LLM sees prior conversation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -1477,6 +1478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1577,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ dirs = "6.0.0"
 futures = "0.3.32"
 open = "5.3.3"
 rand = "0.10.0"
-reqwest = { version = "0.13.2", features = ["json", "stream"] }
+reqwest = { version = "0.13.2", features = ["json", "stream", "form", "query"] }
 rusqlite = { version = "0.38.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
+<p align="center">
+  <img src="assets/logo.svg" width="200" alt="Golem logo — a clay head with אמת (emet) on its forehead" />
+</p>
+
 # Golem
 
 A clay body, animated by words.
 
-Golem is a minimal AI agent harness built in Rust. It has no model of its own — it borrows its intelligence from whatever you plug in: a human at a keyboard, a local LLM, or a cloud API.
+Golem is a minimal AI agent harness built in Rust. It has no model of its own — it borrows its intelligence from whatever you plug in: a human at a keyboard, or a cloud API (Anthropic, Google Gemini).
 
 Built as a learning project to explore ReAct, tool calling, and memory from scratch.
 
@@ -13,6 +17,16 @@ You give a task → Thinker reasons → Tools execute → Observations fed back 
 ```
 
 This is the [ReAct](https://arxiv.org/abs/2210.03629) pattern: **Re**ason + **Act** in a loop until the task is done.
+
+## Providers
+
+| Provider | Auth | Default model | Status |
+|----------|------|---------------|--------|
+| **Anthropic** | OAuth (Claude Pro/Max) or `ANTHROPIC_API_KEY` | `claude-sonnet-4-20250514` | ✅ |
+| **Google Gemini** | OAuth or `GEMINI_API_KEY` | `gemini-3-flash-preview` | ✅ |
+| **Human** | None | — | ✅ |
+
+Adding a new provider: implement the `ProviderConfig` trait (5 methods) + `Thinker` trait. See [AGENTS.md](AGENTS.md).
 
 ## Install
 
@@ -52,18 +66,17 @@ cargo build --release
 # Log in to Anthropic (opens browser for OAuth)
 golem login
 
-# Interactive mode
+# Log in to Google Gemini (opens browser, auto-captures callback)
+golem login google
+
+# Interactive mode (default: Anthropic)
 golem
+
+# Use Gemini
+golem --provider google
 
 # Single task
 golem -r "list files in the current directory"
-
-# golem v0.2.0 — a clay body, animated by words
-#
-# golem> list files in the current directory
-# Thought: I need to list the files...
-# Action: shell:ls -la
-# [shell] ✓ ...
 ```
 
 ## CLI
@@ -77,9 +90,9 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-  -p, --provider <PROVIDER>    LLM provider [default: anthropic] [possible values: human, anthropic]
+  -p, --provider <PROVIDER>    LLM provider [default: anthropic] [possible values: human, anthropic, google]
       --model <MODEL>          Model name (provider-specific, ignored for human)
-  -d, --db <DB>                SQLite database path [default: golem.db]
+  -d, --db <DB>                SQLite database path [default: ~/.golem/golem.db]
   -m, --max-iterations <N>     Max ReAct loop iterations [default: 20]
   -t, --timeout <SECONDS>      Tool execution timeout [default: 30]
       --allow-write            Allow write operations in shell (default: read-only)
@@ -126,8 +139,9 @@ Session history persists across restarts. Use `/new` to clear it and start fresh
 
 Everything is a trait. Everything is swappable.
 
+- **`ProviderConfig`** — defines a provider's identity, auth flow, and thinker construction
 - **`Engine`** — the outermost boundary (`fn run(task) -> answer`)
-- **`Thinker`** — the brain (human, Anthropic, mock — picked via `--provider`)
+- **`Thinker`** — the brain (Anthropic, Gemini, human, mock — picked via `--provider`)
 - **`Tool`** — something the agent can do (shell commands, more coming)
 - **`Command`** — built-in REPL commands (`/help`, `/model`, `/new`, etc.)
 - **`Memory`** — what the agent remembers (task iterations + session history, SQLite-backed)

--- a/src/auth/google_oauth.rs
+++ b/src/auth/google_oauth.rs
@@ -1,0 +1,451 @@
+use anyhow::{Result, bail};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand::RngExt;
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use super::oauth::OAuthCredentials;
+
+const CLIENT_ID: &str = "701529528334-otljpqp2bjvhm7lp2eqktu5ja8uo05g6.apps.googleusercontent.com";
+const CLIENT_SECRET: &str = "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";
+const AUTHORIZE_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const SCOPES: &str = "https://www.googleapis.com/auth/generative-language";
+
+/// 5-minute buffer (in ms) subtracted from token expiry.
+const EXPIRY_BUFFER_MS: u64 = 5 * 60 * 1000;
+
+/// PKCE verifier and challenge pair.
+struct Pkce {
+    verifier: String,
+    challenge: String,
+}
+
+/// Generate a PKCE code verifier and S256 challenge.
+fn generate_pkce() -> Pkce {
+    let mut rng = rand::rng();
+    let bytes: [u8; 32] = rng.random();
+    let verifier = URL_SAFE_NO_PAD.encode(bytes);
+
+    let hash = Sha256::digest(verifier.as_bytes());
+    let challenge = URL_SAFE_NO_PAD.encode(hash);
+
+    Pkce {
+        verifier,
+        challenge,
+    }
+}
+
+/// Generate a random state parameter for CSRF protection.
+fn generate_state() -> String {
+    let mut rng = rand::rng();
+    let bytes: [u8; 16] = rng.random();
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_millis() as u64
+}
+
+/// Calculate expiry timestamp with a safety buffer, using saturating math
+/// to avoid underflow if `expires_in` is unexpectedly small.
+fn expiry_with_buffer(expires_in: u64) -> u64 {
+    now_ms()
+        .saturating_add(expires_in.saturating_mul(1000))
+        .saturating_sub(EXPIRY_BUFFER_MS)
+}
+
+/// Authorization result from the local loopback server.
+pub struct AuthResult {
+    pub url: String,
+    pub verifier: String,
+    pub state: String,
+    pub port: u16,
+}
+
+/// Build the Google authorization URL and bind a local loopback server.
+/// Returns the URL, PKCE verifier, state, and the port the server is on.
+///
+/// The caller should open the URL in a browser, then call
+/// `await_callback()` to wait for the redirect.
+pub async fn prepare_authorize() -> Result<(AuthResult, TcpListener)> {
+    // Bind to a random available port on loopback
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let redirect_uri = format!("http://127.0.0.1:{port}");
+
+    let pkce = generate_pkce();
+    let state = generate_state();
+
+    let params = [
+        ("client_id", CLIENT_ID),
+        ("response_type", "code"),
+        ("redirect_uri", redirect_uri.as_str()),
+        ("scope", SCOPES),
+        ("code_challenge", pkce.challenge.as_str()),
+        ("code_challenge_method", "S256"),
+        ("access_type", "offline"),
+        ("prompt", "consent"),
+        ("state", state.as_str()),
+    ];
+
+    let query = params
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, urlencoded(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let url = format!("{}?{}", AUTHORIZE_URL, query);
+
+    Ok((
+        AuthResult {
+            url,
+            verifier: pkce.verifier,
+            state,
+            port,
+        },
+        listener,
+    ))
+}
+
+/// How long to wait for the OAuth callback before giving up.
+const CALLBACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Wait for Google's redirect to the loopback server and extract the auth code.
+/// Validates the `state` parameter to prevent CSRF.
+/// Times out after 2 minutes if no callback arrives.
+pub async fn await_callback(listener: TcpListener, expected_state: &str) -> Result<String> {
+    let (mut stream, _) = tokio::time::timeout(CALLBACK_TIMEOUT, listener.accept())
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "timed out waiting for OAuth callback ({}s). Try again.",
+                CALLBACK_TIMEOUT.as_secs()
+            )
+        })??;
+
+    let mut buf = vec![0u8; 4096];
+    let n = stream.read(&mut buf).await?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+
+    // Extract the path from "GET /path?query HTTP/1.1"
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("");
+
+    // Parse and URL-decode query parameters
+    let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
+    let params: std::collections::HashMap<String, String> = query
+        .split('&')
+        .filter_map(|p| {
+            let (k, v) = p.split_once('=')?;
+            Some((urldecode(k), urldecode(v)))
+        })
+        .collect();
+
+    // Check for errors from Google
+    if let Some(error) = params.get("error") {
+        let body = format!("Authentication failed: {error}");
+        let response = format!(
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        bail!("Google OAuth error: {error}");
+    }
+
+    // Validate state
+    let state = params.get("state").map(|s| s.as_str()).unwrap_or("");
+    if state != expected_state {
+        let body = "State mismatch — possible CSRF attack.";
+        let response = format!(
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        bail!("OAuth state mismatch: expected {expected_state}, got {state}");
+    }
+
+    let code = params
+        .get("code")
+        .ok_or_else(|| anyhow::anyhow!("no authorization code in callback"))?
+        .to_string();
+
+    // Send a nice response to the browser
+    let body = "✓ Authentication successful! You can close this tab and return to Golem.";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+
+    Ok(code)
+}
+
+/// Exchange an authorization code for tokens.
+pub async fn exchange_code(code: &str, verifier: &str, port: u16) -> Result<OAuthCredentials> {
+    let redirect_uri = format!("http://127.0.0.1:{port}");
+    let params = [
+        ("grant_type", "authorization_code"),
+        ("client_id", CLIENT_ID),
+        ("client_secret", CLIENT_SECRET),
+        ("code", code),
+        ("redirect_uri", redirect_uri.as_str()),
+        ("code_verifier", verifier),
+    ];
+
+    let client = reqwest::Client::new();
+    let resp = client.post(TOKEN_URL).form(&params).send().await?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        bail!("Google token exchange failed: {}", text);
+    }
+
+    let data: TokenResponse = resp.json().await?;
+
+    let refresh = data.refresh_token.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Google did not return a refresh token. \
+             Try revoking access at https://myaccount.google.com/permissions and logging in again."
+        )
+    })?;
+
+    Ok(OAuthCredentials {
+        access: data.access_token,
+        refresh,
+        expires: expiry_with_buffer(data.expires_in),
+    })
+}
+
+/// Refresh an expired access token.
+pub async fn refresh_token(refresh: &str) -> Result<OAuthCredentials> {
+    let params = [
+        ("grant_type", "refresh_token"),
+        ("client_id", CLIENT_ID),
+        ("client_secret", CLIENT_SECRET),
+        ("refresh_token", refresh),
+    ];
+
+    let client = reqwest::Client::new();
+    let resp = client.post(TOKEN_URL).form(&params).send().await?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        bail!("Google token refresh failed: {}", text);
+    }
+
+    let data: TokenResponse = resp.json().await?;
+
+    // Google refresh responses may omit refresh_token (reuse the old one)
+    Ok(OAuthCredentials {
+        access: data.access_token,
+        refresh: data.refresh_token.unwrap_or_else(|| refresh.to_string()),
+        expires: expiry_with_buffer(data.expires_in),
+    })
+}
+
+#[derive(serde::Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_in: u64,
+}
+
+/// Decode a percent-encoded string (e.g. `hello%20world` → `hello world`).
+fn urldecode(s: &str) -> String {
+    let mut out = Vec::with_capacity(s.len());
+    let mut bytes = s.bytes();
+    while let Some(b) = bytes.next() {
+        if b == b'%' {
+            let hi = bytes.next().and_then(hex_digit);
+            let lo = bytes.next().and_then(hex_digit);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push(h << 4 | l);
+            }
+        } else if b == b'+' {
+            out.push(b' ');
+        } else {
+            out.push(b);
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_digit(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Minimal URL encoding for query parameters.
+fn urlencoded(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push_str(&format!("%{:02X}", b));
+            }
+        }
+    }
+    out
+}
+
+/// Verify that a PKCE verifier and challenge are correctly related.
+pub fn verify_pkce(verifier: &str, challenge: &str) -> bool {
+    let hash = Sha256::digest(verifier.as_bytes());
+    let expected = URL_SAFE_NO_PAD.encode(hash);
+    expected == challenge
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_verifier_is_43_chars() {
+        let pkce = generate_pkce();
+        assert_eq!(pkce.verifier.len(), 43);
+    }
+
+    #[test]
+    fn pkce_challenge_is_43_chars() {
+        let pkce = generate_pkce();
+        assert_eq!(pkce.challenge.len(), 43);
+    }
+
+    #[test]
+    fn pkce_verifier_and_challenge_differ() {
+        let pkce = generate_pkce();
+        assert_ne!(pkce.verifier, pkce.challenge);
+    }
+
+    #[test]
+    fn pkce_challenge_matches_verifier() {
+        let pkce = generate_pkce();
+        assert!(verify_pkce(&pkce.verifier, &pkce.challenge));
+    }
+
+    #[test]
+    fn pkce_wrong_verifier_fails() {
+        let pkce = generate_pkce();
+        assert!(!verify_pkce(
+            "wrong-verifier-value-xxxxxxxxxxxxxxxxxx",
+            &pkce.challenge
+        ));
+    }
+
+    #[test]
+    fn pkce_is_random_each_time() {
+        let a = generate_pkce();
+        let b = generate_pkce();
+        assert_ne!(a.verifier, b.verifier);
+        assert_ne!(a.challenge, b.challenge);
+    }
+
+    #[test]
+    fn state_is_random_each_time() {
+        let a = generate_state();
+        let b = generate_state();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn state_is_non_empty() {
+        let state = generate_state();
+        assert!(!state.is_empty());
+    }
+
+    #[test]
+    fn expiry_with_buffer_normal() {
+        // 1 hour = 3600s, buffer = 5min = 300s
+        let expires = expiry_with_buffer(3600);
+        // Should be roughly now + 55 minutes
+        let expected_min = now_ms() + (3300 * 1000);
+        let expected_max = now_ms() + (3600 * 1000);
+        assert!(expires >= expected_min && expires <= expected_max);
+    }
+
+    #[test]
+    fn expiry_with_buffer_small_value_no_underflow() {
+        // If expires_in is 0, should not panic or wrap
+        let expires = expiry_with_buffer(0);
+        // Should be close to now (minus buffer, saturated)
+        assert!(expires <= now_ms());
+    }
+
+    #[test]
+    fn urldecode_basic() {
+        assert_eq!(urldecode("hello%20world"), "hello world");
+        assert_eq!(urldecode("a%3Db%26c"), "a=b&c");
+    }
+
+    #[test]
+    fn urldecode_plus_as_space() {
+        assert_eq!(urldecode("hello+world"), "hello world");
+    }
+
+    #[test]
+    fn urldecode_passthrough() {
+        assert_eq!(urldecode("hello"), "hello");
+    }
+
+    #[test]
+    fn urlencoded_preserves_alphanumeric() {
+        assert_eq!(urlencoded("hello"), "hello");
+    }
+
+    #[test]
+    fn urlencoded_encodes_special_chars() {
+        assert_eq!(urlencoded("a=b&c"), "a%3Db%26c");
+        assert_eq!(urlencoded("foo:bar"), "foo%3Abar");
+    }
+
+    #[test]
+    fn urlencoded_preserves_unreserved() {
+        assert_eq!(urlencoded("a-b_c.d~e"), "a-b_c.d~e");
+    }
+
+    #[test]
+    fn urlencoded_encodes_slashes() {
+        assert_eq!(
+            urlencoded("https://www.googleapis.com/auth/generative-language"),
+            "https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgenerative-language"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_authorize_returns_valid_url() {
+        let (auth, _listener) = prepare_authorize().await.unwrap();
+        assert!(
+            auth.url
+                .starts_with("https://accounts.google.com/o/oauth2/v2/auth?")
+        );
+        assert!(auth.url.contains("client_id="));
+        assert!(auth.url.contains("response_type=code"));
+        assert!(auth.url.contains("redirect_uri=http%3A%2F%2F127.0.0.1"));
+        assert!(auth.url.contains("code_challenge="));
+        assert!(auth.url.contains("code_challenge_method=S256"));
+        assert!(auth.url.contains("access_type=offline"));
+        assert!(auth.url.contains("state="));
+    }
+
+    #[tokio::test]
+    async fn prepare_authorize_binds_to_port() {
+        let (auth, _listener) = prepare_authorize().await.unwrap();
+        assert!(auth.port > 0);
+        assert!(auth.url.contains(&format!("127.0.0.1%3A{}", auth.port)));
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,3 +1,4 @@
+pub mod google_oauth;
 pub mod oauth;
 pub mod storage;
 
@@ -7,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use storage::Credential;
 
 /// Providers that support OAuth login.
-const SUPPORTED_PROVIDERS: &[&str] = &["anthropic"];
+const SUPPORTED_PROVIDERS: &[&str] = &["anthropic", "google"];
 
 /// Complete OAuth login: exchange the authorization code and save credentials.
 ///
@@ -16,13 +17,27 @@ const SUPPORTED_PROVIDERS: &[&str] = &["anthropic"];
 ///
 /// Returns an error if the provider is not supported, the token exchange
 /// fails, or credentials cannot be saved.
-pub async fn login(db_path: &str, provider: &str, code: &str, verifier: &str) -> Result<()> {
+pub async fn login(
+    db_path: &str,
+    provider: &str,
+    code: &str,
+    verifier: &str,
+    port: Option<u16>,
+) -> Result<()> {
     if !SUPPORTED_PROVIDERS.contains(&provider) {
         bail!("unsupported provider: {provider}");
     }
-    let credentials = oauth::exchange_code(code, verifier)
-        .await
-        .context("token exchange failed")?;
+    let credentials = match provider {
+        "google" => {
+            let port = port.ok_or_else(|| anyhow::anyhow!("port required for Google login"))?;
+            google_oauth::exchange_code(code, verifier, port)
+                .await
+                .context("Google token exchange failed")?
+        }
+        _ => oauth::exchange_code(code, verifier)
+            .await
+            .context("token exchange failed")?,
+    };
     let storage = AuthStorage::open(db_path).context("failed to open auth storage")?;
     storage
         .set(provider, Credential::OAuth(credentials))

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -15,6 +15,15 @@ pub enum Credential {
     ApiKey { key: String },
 }
 
+/// A resolved credential ready for use in API calls.
+#[derive(Debug, Clone)]
+pub struct ResolvedCredential {
+    /// The token or API key string.
+    pub token: String,
+    /// Whether this is an OAuth access token (true) or an API key (false).
+    pub is_oauth: bool,
+}
+
 /// Manages credential storage in SQLite.
 ///
 /// Shares a database with memory and config — pass the same connection
@@ -76,16 +85,39 @@ impl AuthStorage {
     /// Get the API key for a provider, handling OAuth token refresh.
     /// Priority: stored OAuth → stored API key → environment variable.
     pub async fn get_api_key(&self, provider: &str, env_var: &str) -> Result<Option<String>> {
+        self.get_credential(provider, env_var)
+            .await
+            .map(|opt| opt.map(|r| r.token))
+    }
+
+    /// Get the resolved credential for a provider, including its type.
+    /// Priority: stored OAuth → stored API key → environment variable.
+    pub async fn get_credential(
+        &self,
+        provider: &str,
+        env_var: &str,
+    ) -> Result<Option<ResolvedCredential>> {
         if let Some(cred) = self.get(provider)? {
             match cred {
-                Credential::ApiKey { key } => return Ok(Some(key)),
+                Credential::ApiKey { key } => {
+                    return Ok(Some(ResolvedCredential {
+                        token: key,
+                        is_oauth: false,
+                    }));
+                }
                 Credential::OAuth(mut oauth) => {
                     if oauth.is_expired() {
-                        let refreshed = super::oauth::refresh_token(&oauth.refresh).await?;
+                        let refreshed = match provider {
+                            "google" => super::google_oauth::refresh_token(&oauth.refresh).await?,
+                            _ => super::oauth::refresh_token(&oauth.refresh).await?,
+                        };
                         oauth = refreshed.clone();
                         self.set(provider, Credential::OAuth(refreshed))?;
                     }
-                    return Ok(Some(oauth.access));
+                    return Ok(Some(ResolvedCredential {
+                        token: oauth.access,
+                        is_oauth: true,
+                    }));
                 }
             }
         }
@@ -94,7 +126,10 @@ impl AuthStorage {
         if let Ok(key) = std::env::var(env_var)
             && !key.is_empty()
         {
-            return Ok(Some(key));
+            return Ok(Some(ResolvedCredential {
+                token: key,
+                is_oauth: false,
+            }));
         }
 
         Ok(None)

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 
 use super::{Command, CommandResult, SessionInfo, StateChange};
-use crate::auth;
-use crate::auth::oauth;
+use crate::provider::provider_config_by_id;
 
 pub struct LoginCommand;
 
@@ -18,35 +17,17 @@ impl Command for LoginCommand {
 
     async fn execute(&self, info: &SessionInfo<'_>) -> CommandResult {
         let provider = info.provider;
-        println!("Logging in to {provider}...\n");
 
-        let (url, verifier) = oauth::build_authorize_url();
-        let _ = open::that(&url);
-
-        println!("Open this URL to authenticate:\n");
-        println!("  {url}\n");
-
-        print!("Paste the authorization code: ");
-        if std::io::Write::flush(&mut std::io::stdout()).is_err() {
+        let Some(config) = provider_config_by_id(provider) else {
+            eprintln!("  ✗ provider {provider} does not support login");
             return CommandResult::Handled;
-        }
+        };
 
-        let mut code = String::new();
-        if std::io::stdin().read_line(&mut code).is_err() {
-            eprintln!("  ✗ failed to read input");
-            return CommandResult::Handled;
-        }
-        let code = code.trim();
+        println!("Logging in to {}...\n", config.display_name());
 
-        if code.is_empty() {
-            eprintln!("  ✗ no authorization code provided");
-            return CommandResult::Handled;
-        }
-
-        println!("\nExchanging code for tokens...");
-        match auth::login(info.db_path, provider, code, &verifier).await {
+        match config.login(info.db_path).await {
             Ok(()) => {
-                println!("  ✓ logged in to {provider}");
+                println!("  ✓ logged in to {}", config.display_name());
                 CommandResult::StateChanged(StateChange::Auth("OAuth ✓".to_string()))
             }
             Err(e) => {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -6,9 +6,6 @@ pub const AUTHOR: &str = env!("CARGO_PKG_AUTHORS");
 pub const HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
 pub const REPO: &str = env!("CARGO_PKG_REPOSITORY");
 
-/// Default Anthropic model when none is specified.
-pub const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
-
 /// Maximum number of prior task summaries to include in session context.
 pub const DEFAULT_SESSION_HISTORY_LIMIT: usize = 50;
 
@@ -43,7 +40,6 @@ mod tests {
         assert!(!AUTHOR.is_empty());
         assert!(!HOMEPAGE.is_empty());
         assert!(!REPO.is_empty());
-        assert!(!DEFAULT_MODEL.is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod engine;
 pub mod events;
 pub mod memory;
 pub mod prompts;
+pub mod provider;
 pub mod spinner;
 pub mod thinker;
 pub mod tools;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,29 +4,19 @@ use std::time::Duration;
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-use golem::auth::oauth;
-use golem::auth::storage::{AuthStorage, Credential};
 use golem::banner::{BannerInfo, print_banner, print_session_summary};
 use golem::commands::{CommandRegistry, CommandResult, SessionInfo, StateChange};
 use golem::config::Config;
-use golem::consts::{DEFAULT_MODEL, default_db_path};
+use golem::consts::default_db_path;
 use golem::engine::Engine;
 use golem::engine::react::{ReactConfig, ReactEngine};
 use golem::memory::sqlite::SqliteMemory;
-use golem::thinker::Thinker;
-use golem::thinker::anthropic::AnthropicThinker;
-use golem::thinker::human::HumanThinker;
+use golem::provider::{LoginProvider, Provider, build_provider, handle_login, handle_logout};
 use golem::tools::ToolRegistry;
 use golem::tools::shell::{ShellConfig, ShellMode, ShellTool};
-
-#[derive(Debug, Clone, ValueEnum)]
-enum Provider {
-    Human,
-    Anthropic,
-}
 
 #[derive(Parser)]
 #[command(name = "golem", version, about = "A clay body, animated by words.")]
@@ -87,11 +77,6 @@ enum Command {
     },
 }
 
-#[derive(Debug, Clone, ValueEnum)]
-enum LoginProvider {
-    Anthropic,
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -99,12 +84,8 @@ async fn main() -> anyhow::Result<()> {
     // Handle subcommands
     if let Some(command) = &cli.command {
         match command {
-            Command::Login { provider } => {
-                return handle_login(provider).await;
-            }
-            Command::Logout { provider } => {
-                return handle_logout(provider);
-            }
+            Command::Login { provider } => return handle_login(provider).await,
+            Command::Logout { provider } => return handle_logout(provider),
         }
     }
 
@@ -121,51 +102,11 @@ async fn main() -> anyhow::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
 
-    // Wire up the thinker based on provider + model
-    let (thinker, provider_name, mut model_name, mut auth_status): (
-        Box<dyn Thinker>,
-        &str,
-        String,
-        String,
-    ) = match cli.provider {
-        Provider::Human => {
-            if cli.model.is_some() {
-                eprintln!("warning: --model is ignored for human provider");
-            }
-            (
-                Box::new(HumanThinker),
-                "human",
-                "—".to_string(),
-                "N/A".to_string(),
-            )
-        }
-        Provider::Anthropic => {
-            let auth = AuthStorage::open(&db_path)?;
-            let auth_status = match auth.get("anthropic")? {
-                Some(Credential::OAuth(_)) => "OAuth ✓".to_string(),
-                Some(Credential::ApiKey { .. }) => "API key ✓".to_string(),
-                None => {
-                    if std::env::var("ANTHROPIC_API_KEY")
-                        .map(|k| !k.is_empty())
-                        .unwrap_or(false)
-                    {
-                        "API key (env) ✓".to_string()
-                    } else {
-                        "not authenticated".to_string()
-                    }
-                }
-            };
-            // Model resolution: --model flag > config DB > default
-            let model = cli.model.clone().or_else(|| {
-                Config::open(&db_path)
-                    .ok()
-                    .and_then(|c| c.get("model").ok().flatten())
-            });
-            let thinker = Box::new(AnthropicThinker::new(model.clone(), auth));
-            let model_name = model.unwrap_or_else(|| DEFAULT_MODEL.to_string());
-            (thinker, "anthropic", model_name, auth_status)
-        }
-    };
+    // Wire up the provider
+    let setup = build_provider(&cli.provider, &db_path, cli.model.clone())?;
+    let provider_name = setup.name;
+    let mut model_name = setup.model;
+    let mut auth_status = setup.auth_status;
 
     let shell_mode = if cli.allow_write {
         ShellMode::ReadWrite
@@ -222,7 +163,7 @@ async fn main() -> anyhow::Result<()> {
         tool_timeout: Duration::from_secs(cli.timeout),
     };
 
-    let mut engine = ReactEngine::new(thinker, tools, memory, config);
+    let mut engine = ReactEngine::new(setup.thinker, tools, memory, config);
     let commands = CommandRegistry::new();
     let app_config = Config::open(&db_path)?;
 
@@ -319,59 +260,5 @@ async fn main() -> anyhow::Result<()> {
     }
 
     print_session_summary(engine.session_usage());
-    Ok(())
-}
-
-async fn handle_login(provider: &LoginProvider) -> anyhow::Result<()> {
-    let db_path = default_db_path();
-    let db_str = db_path.to_string_lossy();
-
-    if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let provider_name = match provider {
-        LoginProvider::Anthropic => "anthropic",
-    };
-
-    println!("Logging in to {provider_name} (Claude Pro/Max)...\n");
-
-    let (url, verifier) = oauth::build_authorize_url();
-    let _ = open::that(&url);
-
-    println!("Open this URL to authenticate:\n");
-    println!("  {url}\n");
-
-    print!("Paste the authorization code: ");
-    io::stdout().flush()?;
-    let mut code = String::new();
-    io::stdin().read_line(&mut code)?;
-    let code = code.trim();
-
-    if code.is_empty() {
-        anyhow::bail!("no authorization code provided");
-    }
-
-    println!("\nExchanging code for tokens...");
-    golem::auth::login(&db_str, provider_name, code, &verifier).await?;
-
-    println!("✓ Logged in to {provider_name} successfully!");
-    Ok(())
-}
-
-fn handle_logout(provider: &LoginProvider) -> anyhow::Result<()> {
-    let db_path = default_db_path();
-    let db_str = db_path.to_string_lossy();
-
-    if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let provider_name = match provider {
-        LoginProvider::Anthropic => "anthropic",
-    };
-
-    golem::auth::logout(&db_str, provider_name)?;
-    println!("✓ Logged out from {provider_name}.");
     Ok(())
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,286 @@
+//! Provider wiring: trait-based provider config, thinker construction, login/logout flows.
+
+use std::io::{self, Write};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use clap::ValueEnum;
+
+use crate::auth::storage::{AuthStorage, Credential};
+use crate::config::Config;
+use crate::consts::default_db_path;
+use crate::thinker::Thinker;
+
+// --- Provider trait ---
+
+/// Defines everything a provider needs: identity, auth, thinker construction, and login flow.
+#[async_trait]
+pub trait ProviderConfig: Send + Sync {
+    /// Internal identifier used for storage and auth routing (e.g. `"anthropic"`).
+    fn id(&self) -> &'static str;
+
+    /// Human-readable label for prompts (e.g. `"Anthropic (Claude Pro/Max)"`).
+    fn display_name(&self) -> &'static str;
+
+    /// Environment variable name for API key fallback (e.g. `"ANTHROPIC_API_KEY"`).
+    fn env_var(&self) -> &'static str;
+
+    /// Build the thinker for this provider.
+    fn build_thinker(&self, model: Option<String>, auth: AuthStorage) -> Box<dyn Thinker>;
+
+    /// Run the interactive login flow, storing credentials in `db_path`.
+    async fn login(&self, db_path: &str) -> Result<()>;
+}
+
+// --- Provider implementations ---
+
+mod anthropic_provider {
+    use super::*;
+    use crate::auth::oauth;
+    use crate::thinker::anthropic::AnthropicThinker;
+
+    pub struct Anthropic;
+
+    #[async_trait]
+    impl ProviderConfig for Anthropic {
+        fn id(&self) -> &'static str {
+            "anthropic"
+        }
+
+        fn display_name(&self) -> &'static str {
+            "Anthropic (Claude Pro/Max)"
+        }
+
+        fn env_var(&self) -> &'static str {
+            "ANTHROPIC_API_KEY"
+        }
+
+        fn build_thinker(&self, model: Option<String>, auth: AuthStorage) -> Box<dyn Thinker> {
+            Box::new(AnthropicThinker::new(model, auth))
+        }
+
+        async fn login(&self, db_path: &str) -> Result<()> {
+            let (url, verifier) = oauth::build_authorize_url();
+            let _ = open::that(&url);
+
+            println!("Open this URL to authenticate:\n");
+            println!("  {url}\n");
+
+            print!("Paste the authorization code: ");
+            io::stdout().flush()?;
+            let mut code = String::new();
+            io::stdin().read_line(&mut code)?;
+            let code = code.trim();
+
+            if code.is_empty() {
+                anyhow::bail!("no authorization code provided");
+            }
+
+            println!("\nExchanging code for tokens...");
+            crate::auth::login(db_path, self.id(), code, &verifier, None).await?;
+            Ok(())
+        }
+    }
+}
+
+mod google_provider {
+    use super::*;
+    use crate::auth::google_oauth;
+    use crate::thinker::gemini::GeminiThinker;
+
+    pub struct Google;
+
+    #[async_trait]
+    impl ProviderConfig for Google {
+        fn id(&self) -> &'static str {
+            "google"
+        }
+
+        fn display_name(&self) -> &'static str {
+            "Google (Gemini)"
+        }
+
+        fn env_var(&self) -> &'static str {
+            "GEMINI_API_KEY"
+        }
+
+        fn build_thinker(&self, model: Option<String>, auth: AuthStorage) -> Box<dyn Thinker> {
+            Box::new(GeminiThinker::new(model, auth))
+        }
+
+        async fn login(&self, db_path: &str) -> Result<()> {
+            let (auth_result, listener) = google_oauth::prepare_authorize().await?;
+
+            let _ = open::that(&auth_result.url);
+            println!("Open this URL to authenticate:\n");
+            println!("  {}\n", auth_result.url);
+            println!(
+                "Waiting for callback on http://127.0.0.1:{}...",
+                auth_result.port
+            );
+
+            let code = google_oauth::await_callback(listener, &auth_result.state).await?;
+
+            println!("\nExchanging code for tokens...");
+            crate::auth::login(
+                db_path,
+                self.id(),
+                &code,
+                &auth_result.verifier,
+                Some(auth_result.port),
+            )
+            .await?;
+            Ok(())
+        }
+    }
+}
+
+/// Look up a `ProviderConfig` by its string identifier (e.g. `"anthropic"`, `"google"`).
+/// Used by REPL commands that only have the provider name as a string.
+pub fn provider_config_by_id(id: &str) -> Option<Box<dyn ProviderConfig>> {
+    match id {
+        "anthropic" => Some(Box::new(anthropic_provider::Anthropic)),
+        "google" => Some(Box::new(google_provider::Google)),
+        _ => None,
+    }
+}
+
+// --- CLI enums ---
+
+/// Runtime provider selection for the main CLI.
+#[derive(Debug, Clone, ValueEnum)]
+pub enum Provider {
+    Human,
+    Anthropic,
+    Google,
+}
+
+impl Provider {
+    /// Get the `ProviderConfig` for this provider, if it has one.
+    /// Human provider has no config (no auth, no model defaults).
+    fn config(&self) -> Option<Box<dyn ProviderConfig>> {
+        match self {
+            Self::Human => None,
+            Self::Anthropic => Some(Box::new(anthropic_provider::Anthropic)),
+            Self::Google => Some(Box::new(google_provider::Google)),
+        }
+    }
+}
+
+/// Provider selection for login/logout subcommands.
+#[derive(Debug, Clone, ValueEnum)]
+pub enum LoginProvider {
+    Anthropic,
+    Google,
+}
+
+impl LoginProvider {
+    /// Get the `ProviderConfig` for this login provider.
+    fn config(&self) -> Box<dyn ProviderConfig> {
+        match self {
+            Self::Anthropic => Box::new(anthropic_provider::Anthropic),
+            Self::Google => Box::new(google_provider::Google),
+        }
+    }
+}
+
+// --- Provider wiring ---
+
+/// Everything needed to run a provider, resolved at startup.
+pub struct ProviderSetup {
+    pub thinker: Box<dyn Thinker>,
+    pub name: &'static str,
+    pub model: String,
+    pub auth_status: String,
+}
+
+/// Check auth status for a provider: stored credential → env var → not authenticated.
+fn check_auth_status(auth: &AuthStorage, config: &dyn ProviderConfig) -> String {
+    match auth.get(config.id()) {
+        Ok(Some(Credential::OAuth(_))) => "OAuth ✓".to_string(),
+        Ok(Some(Credential::ApiKey { .. })) => "API key ✓".to_string(),
+        _ => {
+            if std::env::var(config.env_var())
+                .map(|k| !k.is_empty())
+                .unwrap_or(false)
+            {
+                "API key (env) ✓".to_string()
+            } else {
+                "not authenticated".to_string()
+            }
+        }
+    }
+}
+
+/// Resolve model override: --model flag > config DB > None (let thinker use its default).
+fn resolve_model(cli_model: Option<String>, db_path: &str) -> Option<String> {
+    cli_model.or_else(|| {
+        Config::open(db_path)
+            .ok()
+            .and_then(|c| c.get("model").ok().flatten())
+    })
+}
+
+/// Build the thinker, auth status, and model for the selected provider.
+pub fn build_provider(
+    provider: &Provider,
+    db_path: &str,
+    cli_model: Option<String>,
+) -> Result<ProviderSetup> {
+    let Some(config) = provider.config() else {
+        // Human provider — no auth, no model
+        if cli_model.is_some() {
+            eprintln!("warning: --model is ignored for human provider");
+        }
+        return Ok(ProviderSetup {
+            thinker: Box::new(crate::thinker::human::HumanThinker),
+            name: "human",
+            model: "—".to_string(),
+            auth_status: "N/A".to_string(),
+        });
+    };
+
+    let auth = AuthStorage::open(db_path)?;
+    let auth_status = check_auth_status(&auth, config.as_ref());
+    let model = resolve_model(cli_model, db_path);
+    let thinker = config.build_thinker(model, auth);
+    let display = thinker.model().to_string();
+
+    Ok(ProviderSetup {
+        thinker,
+        name: config.id(),
+        model: display,
+        auth_status,
+    })
+}
+
+// --- Login / Logout ---
+
+pub async fn handle_login(provider: &LoginProvider) -> Result<()> {
+    let db_path = default_db_path();
+    let db_str = db_path.to_string_lossy();
+
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let config = provider.config();
+    println!("Logging in to {}...\n", config.display_name());
+    config.login(&db_str).await?;
+    println!("✓ Logged in to {} successfully!", config.display_name());
+    Ok(())
+}
+
+pub fn handle_logout(provider: &LoginProvider) -> Result<()> {
+    let db_path = default_db_path();
+    let db_str = db_path.to_string_lossy();
+
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let config = provider.config();
+    crate::auth::logout(&db_str, config.id())?;
+    println!("✓ Logged out from {}.", config.display_name());
+    Ok(())
+}

--- a/src/thinker/anthropic.rs
+++ b/src/thinker/anthropic.rs
@@ -3,8 +3,10 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::auth::AuthStorage;
-use crate::consts::DEFAULT_MODEL;
 use crate::memory::MemoryEntry;
+
+/// Default Anthropic model when none is specified.
+const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
 use crate::prompts::build_react_system_prompt_with_session;
 use crate::tools::Outcome;
 

--- a/src/thinker/gemini.rs
+++ b/src/thinker/gemini.rs
@@ -1,0 +1,678 @@
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::AuthStorage;
+use crate::auth::storage::ResolvedCredential;
+use crate::memory::MemoryEntry;
+
+/// Default Gemini model when none is specified.
+const DEFAULT_MODEL: &str = "gemini-3-flash-preview";
+use crate::prompts::build_react_system_prompt_with_session;
+use crate::tools::Outcome;
+
+use super::{
+    Context, MAX_PARSE_RETRIES, ModelInfo, PARSE_RETRY_PROMPT, StepResult, Thinker, TokenUsage,
+    parse_response,
+};
+
+const API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
+
+/// An LLM thinker that calls the Google Gemini API.
+pub struct GeminiThinker {
+    model: String,
+    auth: AuthStorage,
+}
+
+impl GeminiThinker {
+    pub fn new(model: Option<String>, auth: AuthStorage) -> Self {
+        Self {
+            model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+            auth,
+        }
+    }
+
+    fn build_contents(context: &Context) -> Vec<Content> {
+        let mut contents: Vec<Content> = Vec::new();
+
+        // Prepend session history as prior task/answer pairs
+        for (i, entry) in context.session_history.iter().enumerate() {
+            contents.push(Content {
+                role: "user".to_string(),
+                parts: vec![Part {
+                    text: format!(
+                        "[Prior task {}/{}] {}",
+                        i + 1,
+                        context.session_history.len(),
+                        entry.task
+                    ),
+                }],
+            });
+            contents.push(Content {
+                role: "model".to_string(),
+                parts: vec![Part {
+                    text: serde_json::json!({
+                        "thought": "completed",
+                        "answer": entry.answer
+                    })
+                    .to_string(),
+                }],
+            });
+        }
+
+        // The current task
+        contents.push(Content {
+            role: "user".to_string(),
+            parts: vec![Part {
+                text: format!("Task: {}", context.task),
+            }],
+        });
+
+        // Convert history into model/user content pairs
+        for entry in &context.history {
+            match entry {
+                MemoryEntry::Task { .. } => {
+                    // Already handled as the first message
+                }
+                MemoryEntry::Iteration { thought, results } => {
+                    let calls: Vec<serde_json::Value> = results
+                        .iter()
+                        .map(|r| {
+                            serde_json::json!({
+                                "tool": r.tool,
+                                "args": {}
+                            })
+                        })
+                        .collect();
+
+                    let model_msg = serde_json::json!({
+                        "thought": thought,
+                        "action": {
+                            "calls": calls
+                        }
+                    });
+
+                    contents.push(Content {
+                        role: "model".to_string(),
+                        parts: vec![Part {
+                            text: model_msg.to_string(),
+                        }],
+                    });
+
+                    let mut observation = String::from("Tool results:\n");
+                    for result in results {
+                        match &result.outcome {
+                            Outcome::Success(out) => {
+                                observation.push_str(&format!("[{}] ✓ {}\n", result.tool, out));
+                            }
+                            Outcome::Error(err) => {
+                                observation.push_str(&format!("[{}] ✗ {}\n", result.tool, err));
+                            }
+                        }
+                    }
+
+                    contents.push(Content {
+                        role: "user".to_string(),
+                        parts: vec![Part { text: observation }],
+                    });
+                }
+                MemoryEntry::Answer { .. } => {
+                    // Shouldn't appear in mid-loop context
+                }
+            }
+        }
+
+        contents
+    }
+}
+
+/// Raw API response: extracted text + optional token usage.
+struct RawResponse {
+    text: String,
+    usage: Option<TokenUsage>,
+}
+
+/// Apply Gemini auth to a request: Bearer token for OAuth, query param for API keys.
+fn apply_auth(
+    builder: reqwest::RequestBuilder,
+    credential: &ResolvedCredential,
+) -> reqwest::RequestBuilder {
+    if credential.is_oauth {
+        builder.header("Authorization", format!("Bearer {}", credential.token))
+    } else {
+        builder.query(&[("key", &credential.token)])
+    }
+}
+
+impl GeminiThinker {
+    /// Send contents to the Gemini API and return the raw text + usage.
+    async fn call_api(
+        &self,
+        credential: &ResolvedCredential,
+        system: &str,
+        contents: &[Content],
+    ) -> Result<RawResponse> {
+        let url = format!("{}/models/{}:generateContent", API_BASE, self.model);
+
+        let body = ApiRequest {
+            system_instruction: Some(SystemInstruction {
+                parts: vec![Part {
+                    text: system.to_string(),
+                }],
+            }),
+            contents,
+            generation_config: Some(GenerationConfig {
+                response_mime_type: "application/json".to_string(),
+            }),
+        };
+
+        let client = reqwest::Client::new();
+        let req = client.post(&url).header("Content-Type", "application/json");
+        let resp = apply_auth(req, credential).json(&body).send().await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            bail!("Gemini API error ({}): {}", status, text);
+        }
+
+        let api_resp: ApiResponse = resp.json().await?;
+
+        let text = api_resp
+            .candidates
+            .into_iter()
+            .flat_map(|c| c.content.parts)
+            .map(|p| p.text)
+            .collect::<Vec<_>>()
+            .join("");
+
+        if text.is_empty() {
+            bail!("Gemini API returned empty response");
+        }
+
+        let usage = api_resp.usage_metadata.map(|u| TokenUsage {
+            input_tokens: u.prompt_token_count,
+            output_tokens: u.candidates_token_count,
+        });
+
+        Ok(RawResponse { text, usage })
+    }
+
+    /// Fetch the list of models from the Gemini API.
+    async fn fetch_models(&self, credential: &ResolvedCredential) -> Result<Vec<ModelInfo>> {
+        let url = format!("{}/models", API_BASE);
+
+        let client = reqwest::Client::new();
+        let req = client.get(&url);
+        let resp = apply_auth(req, credential).send().await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            bail!("Gemini models API error ({status}): {text}");
+        }
+
+        let list: ModelsListResponse = resp.json().await?;
+
+        Ok(parse_models_response(list))
+    }
+}
+
+#[async_trait]
+impl Thinker for GeminiThinker {
+    async fn models(&self) -> Result<Vec<ModelInfo>> {
+        let credential = self
+            .auth
+            .get_credential("google", "GEMINI_API_KEY")
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no Google credentials found. Run `golem login google` or set GEMINI_API_KEY."
+                )
+            })?;
+
+        self.fetch_models(&credential).await
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    fn set_model(&mut self, model: String) {
+        self.model = model;
+    }
+
+    async fn next_step(&self, context: &Context) -> Result<StepResult> {
+        let credential = self
+            .auth
+            .get_credential("google", "GEMINI_API_KEY")
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no Google credentials found. Run `golem login google` or set GEMINI_API_KEY."
+                )
+            })?;
+
+        let system = build_react_system_prompt_with_session(
+            &context.available_tools,
+            !context.session_history.is_empty(),
+        );
+        let mut contents = Self::build_contents(context);
+        let mut total_usage = TokenUsage::default();
+
+        for attempt in 0..=MAX_PARSE_RETRIES {
+            let raw = self.call_api(&credential, &system, &contents).await?;
+
+            if let Some(usage) = raw.usage {
+                total_usage.add(usage);
+            }
+
+            match parse_response(&raw.text) {
+                Ok(step) => {
+                    let combined = if total_usage.total() > 0 {
+                        Some(total_usage)
+                    } else {
+                        None
+                    };
+                    return Ok(StepResult {
+                        step,
+                        usage: combined,
+                    });
+                }
+                Err(parse_err) => {
+                    if attempt < MAX_PARSE_RETRIES {
+                        eprintln!(
+                            "warning: LLM returned invalid JSON (attempt {}), retrying with correction",
+                            attempt + 1
+                        );
+                        contents.push(Content {
+                            role: "model".to_string(),
+                            parts: vec![Part { text: raw.text }],
+                        });
+                        contents.push(Content {
+                            role: "user".to_string(),
+                            parts: vec![Part {
+                                text: PARSE_RETRY_PROMPT.to_string(),
+                            }],
+                        });
+                    } else {
+                        return Err(parse_err);
+                    }
+                }
+            }
+        }
+
+        bail!("unexpected: parse retry loop exited without result")
+    }
+}
+
+// --- API types ---
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_instruction: Option<SystemInstruction>,
+    contents: &'a [Content],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generation_config: Option<GenerationConfig>,
+}
+
+#[derive(Serialize)]
+struct SystemInstruction {
+    parts: Vec<Part>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Content {
+    role: String,
+    parts: Vec<Part>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Part {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct GenerationConfig {
+    #[serde(rename = "responseMimeType")]
+    response_mime_type: String,
+}
+
+#[derive(Deserialize)]
+struct ApiResponse {
+    #[serde(default)]
+    candidates: Vec<Candidate>,
+    #[serde(rename = "usageMetadata")]
+    usage_metadata: Option<UsageMetadata>,
+}
+
+#[derive(Deserialize)]
+struct Candidate {
+    content: CandidateContent,
+}
+
+#[derive(Deserialize)]
+struct CandidateContent {
+    parts: Vec<ResponsePart>,
+}
+
+#[derive(Deserialize)]
+struct ResponsePart {
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct UsageMetadata {
+    #[serde(rename = "promptTokenCount")]
+    prompt_token_count: u64,
+    #[serde(rename = "candidatesTokenCount")]
+    candidates_token_count: u64,
+}
+
+// --- Models API types ---
+
+#[derive(Deserialize)]
+struct ModelsListResponse {
+    models: Vec<ModelEntry>,
+}
+
+#[derive(Deserialize)]
+struct ModelEntry {
+    /// Full name like "models/gemini-2.0-flash"
+    name: String,
+    #[serde(rename = "displayName")]
+    display_name: String,
+    /// Supported generation methods
+    #[serde(rename = "supportedGenerationMethods", default)]
+    supported_generation_methods: Vec<String>,
+}
+
+/// Filter to models that support generateContent, strip "models/" prefix, sort.
+fn parse_models_response(list: ModelsListResponse) -> Vec<ModelInfo> {
+    let mut models: Vec<ModelInfo> = list
+        .models
+        .into_iter()
+        .filter(|m| {
+            m.supported_generation_methods
+                .iter()
+                .any(|method| method == "generateContent")
+        })
+        .map(|m| {
+            let id = m
+                .name
+                .strip_prefix("models/")
+                .unwrap_or(&m.name)
+                .to_string();
+            ModelInfo {
+                id,
+                display_name: m.display_name,
+                created_at: None,
+            }
+        })
+        .collect();
+
+    models.sort_by(|a, b| a.id.cmp(&b.id));
+    models
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::SessionEntry;
+    use crate::thinker::Context;
+    use crate::tools::{Outcome, ToolResult};
+
+    #[test]
+    fn build_contents_task_only() {
+        let context = Context {
+            task: "do something".to_string(),
+            history: vec![],
+            session_history: vec![],
+            available_tools: vec![],
+        };
+
+        let contents = GeminiThinker::build_contents(&context);
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0].role, "user");
+        assert_eq!(contents[0].parts[0].text, "Task: do something");
+    }
+
+    #[test]
+    fn build_contents_with_iteration_history() {
+        let context = Context {
+            task: "check kernel".to_string(),
+            history: vec![
+                MemoryEntry::Task {
+                    content: "check kernel".to_string(),
+                },
+                MemoryEntry::Iteration {
+                    thought: "let me check".to_string(),
+                    results: vec![ToolResult {
+                        tool: "shell".to_string(),
+                        outcome: Outcome::Success("6.18.8".to_string()),
+                    }],
+                },
+            ],
+            session_history: vec![],
+            available_tools: vec![],
+        };
+
+        let contents = GeminiThinker::build_contents(&context);
+        assert_eq!(contents.len(), 3);
+        assert_eq!(contents[0].role, "user");
+        assert_eq!(contents[1].role, "model");
+        assert!(contents[1].parts[0].text.contains("let me check"));
+        assert_eq!(contents[2].role, "user");
+        assert!(contents[2].parts[0].text.contains("6.18.8"));
+        assert!(contents[2].parts[0].text.contains("✓"));
+    }
+
+    #[test]
+    fn build_contents_with_error_result() {
+        let context = Context {
+            task: "test".to_string(),
+            history: vec![
+                MemoryEntry::Task {
+                    content: "test".to_string(),
+                },
+                MemoryEntry::Iteration {
+                    thought: "try something".to_string(),
+                    results: vec![ToolResult {
+                        tool: "shell".to_string(),
+                        outcome: Outcome::Error("command not found".to_string()),
+                    }],
+                },
+            ],
+            session_history: vec![],
+            available_tools: vec![],
+        };
+
+        let contents = GeminiThinker::build_contents(&context);
+        assert_eq!(contents.len(), 3);
+        assert!(contents[2].parts[0].text.contains("✗"));
+        assert!(contents[2].parts[0].text.contains("command not found"));
+    }
+
+    #[test]
+    fn build_contents_includes_session_history() {
+        let context = Context {
+            task: "delete the biggest file".to_string(),
+            history: vec![],
+            session_history: vec![SessionEntry {
+                task: "list files in /tmp".to_string(),
+                answer: "a.txt (10KB), b.txt (50KB), c.txt (1KB)".to_string(),
+            }],
+            available_tools: vec![],
+        };
+
+        let contents = GeminiThinker::build_contents(&context);
+        assert_eq!(contents.len(), 3);
+        assert_eq!(contents[0].role, "user");
+        assert!(contents[0].parts[0].text.contains("list files in /tmp"));
+        assert_eq!(contents[1].role, "model");
+        assert!(contents[1].parts[0].text.contains("a.txt (10KB)"));
+        assert_eq!(contents[2].role, "user");
+        assert!(
+            contents[2].parts[0]
+                .text
+                .contains("delete the biggest file")
+        );
+    }
+
+    #[test]
+    fn build_contents_session_history_before_current_task() {
+        let context = Context {
+            task: "current task".to_string(),
+            history: vec![],
+            session_history: vec![
+                SessionEntry {
+                    task: "first".to_string(),
+                    answer: "answer 1".to_string(),
+                },
+                SessionEntry {
+                    task: "second".to_string(),
+                    answer: "answer 2".to_string(),
+                },
+            ],
+            available_tools: vec![],
+        };
+
+        let contents = GeminiThinker::build_contents(&context);
+        assert_eq!(contents.len(), 5);
+        assert!(contents[0].parts[0].text.contains("first"));
+        assert!(contents[1].parts[0].text.contains("answer 1"));
+        assert!(contents[2].parts[0].text.contains("second"));
+        assert!(contents[3].parts[0].text.contains("answer 2"));
+        assert!(contents[4].parts[0].text.contains("current task"));
+    }
+
+    #[test]
+    fn build_contents_ignores_answer_entries() {
+        let context = Context {
+            task: "test".to_string(),
+            history: vec![
+                MemoryEntry::Task {
+                    content: "test".to_string(),
+                },
+                MemoryEntry::Answer {
+                    thought: "done".to_string(),
+                    content: "42".to_string(),
+                },
+            ],
+            session_history: vec![],
+            available_tools: vec![],
+        };
+
+        let contents = GeminiThinker::build_contents(&context);
+        assert_eq!(contents.len(), 1);
+    }
+
+    #[test]
+    fn build_contents_uses_model_role() {
+        let context = Context {
+            task: "test".to_string(),
+            history: vec![
+                MemoryEntry::Task {
+                    content: "test".to_string(),
+                },
+                MemoryEntry::Iteration {
+                    thought: "thinking".to_string(),
+                    results: vec![ToolResult {
+                        tool: "shell".to_string(),
+                        outcome: Outcome::Success("ok".to_string()),
+                    }],
+                },
+            ],
+            session_history: vec![],
+            available_tools: vec![],
+        };
+
+        let contents = GeminiThinker::build_contents(&context);
+        // Gemini uses "model" not "assistant"
+        assert_eq!(contents[1].role, "model");
+    }
+
+    // --- Models API parsing ---
+
+    fn sample_models_response() -> ModelsListResponse {
+        serde_json::from_str(
+            r#"{
+                "models": [
+                    {
+                        "name": "models/gemini-3-flash-preview",
+                        "displayName": "Gemini 3 Flash Preview",
+                        "supportedGenerationMethods": ["generateContent", "countTokens"]
+                    },
+                    {
+                        "name": "models/gemini-3.1-pro-preview",
+                        "displayName": "Gemini 3.1 Pro Preview",
+                        "supportedGenerationMethods": ["generateContent", "countTokens"]
+                    },
+                    {
+                        "name": "models/embedding-001",
+                        "displayName": "Embedding 001",
+                        "supportedGenerationMethods": ["embedContent"]
+                    },
+                    {
+                        "name": "models/gemini-2.5-flash",
+                        "displayName": "Gemini 2.5 Flash",
+                        "supportedGenerationMethods": ["generateContent", "countTokens"]
+                    }
+                ]
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn parse_models_filters_non_generate_models() {
+        let models = parse_models_response(sample_models_response());
+        assert!(models.iter().all(|m| m.id != "embedding-001"));
+    }
+
+    #[test]
+    fn parse_models_strips_prefix() {
+        let models = parse_models_response(sample_models_response());
+        assert!(models.iter().any(|m| m.id == "gemini-3-flash-preview"));
+        assert!(models.iter().all(|m| !m.id.starts_with("models/")));
+    }
+
+    #[test]
+    fn parse_models_sorted_by_id() {
+        let models = parse_models_response(sample_models_response());
+        let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "gemini-2.5-flash",
+                "gemini-3-flash-preview",
+                "gemini-3.1-pro-preview",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_models_maps_display_name() {
+        let models = parse_models_response(sample_models_response());
+        let flash = models
+            .iter()
+            .find(|m| m.id == "gemini-3-flash-preview")
+            .unwrap();
+        assert_eq!(flash.display_name, "Gemini 3 Flash Preview");
+    }
+
+    #[test]
+    fn parse_models_empty_response() {
+        let list: ModelsListResponse = serde_json::from_str(r#"{"models": []}"#).unwrap();
+        let models = parse_models_response(list);
+        assert!(models.is_empty());
+    }
+
+    #[test]
+    fn parse_models_no_created_at() {
+        let models = parse_models_response(sample_models_response());
+        assert!(models.iter().all(|m| m.created_at.is_none()));
+    }
+}

--- a/src/thinker/mod.rs
+++ b/src/thinker/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod gemini;
 pub mod human;
 pub mod mock;
 

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -322,7 +322,7 @@ fn authorize_url_is_unique_per_call() {
 
 #[tokio::test]
 async fn login_rejects_unsupported_provider() {
-    let err = auth::login(":memory:", "openai", "code", "verifier")
+    let err = auth::login(":memory:", "openai", "code", "verifier", None)
         .await
         .unwrap_err();
     assert!(
@@ -333,7 +333,7 @@ async fn login_rejects_unsupported_provider() {
 
 #[tokio::test]
 async fn login_rejects_empty_provider() {
-    let err = auth::login(":memory:", "", "code", "verifier")
+    let err = auth::login(":memory:", "", "code", "verifier", None)
         .await
         .unwrap_err();
     assert!(


### PR DESCRIPTION
Closes #6

## What

Adds Google Gemini as a second LLM provider, with full OAuth 2.0 PKCE authentication.

## New files

- **`src/auth/google_oauth.rs`** — Google OAuth 2.0 flow (PKCE, loopback redirect with local HTTP server, state/CSRF validation, form-urlencoded token exchange + refresh)
- **`src/thinker/gemini.rs`** — Gemini API thinker (`generateContent` endpoint, system instructions, JSON response mode, model listing, API key vs OAuth auth detection)

## Changes

| File | Change |
|------|--------|
| `src/auth/mod.rs` | Route login/token exchange to Google or Anthropic based on provider |
| `src/auth/storage.rs` | Route token refresh to Google or Anthropic based on provider |
| `src/commands/login.rs` | Google login via loopback server; Anthropic via paste flow |
| `src/consts.rs` | Removed default model constants (moved into thinker modules) |
| `src/thinker/anthropic.rs` | Owns its own `DEFAULT_MODEL` constant |
| `src/thinker/gemini.rs` | Owns its own `DEFAULT_MODEL` constant |
| `src/thinker/mod.rs` | Register `gemini` module |
| `src/main.rs` | Add `Google` provider variant, refactor provider wiring (see below) |
| `Cargo.toml` | Add reqwest `form` + `query` features |

## main.rs refactor

Extracted provider logic out of `main()` into focused functions:

| Function / Method | Purpose |
|-------------------|---------|
| `build_provider()` | Creates thinker + resolves auth status and model for any provider |
| `check_auth_status()` | Shared OAuth / API key / env var detection |
| `resolve_model()` | `--model` flag → config DB → `None` (thinker uses its own default) |
| `LoginProvider::id()` | Internal identifier for storage and auth routing |
| `LoginProvider::display_name()` | Human-readable label for login prompts |

Default models are fully encapsulated in each thinker — `main.rs` reads them back via `thinker.model()`, never imports model constants.

## Review feedback addressed

All 10 Copilot review comments resolved:
- ✅ Replaced deprecated OOB redirect with loopback `http://127.0.0.1:<port>`
- ✅ Added `state` parameter for CSRF protection
- ✅ Switched token exchange/refresh to `application/x-www-form-urlencoded`
- ✅ Saturating math for token expiry buffer (no u64 underflow)
- ✅ API key auth via `?key=` query param, OAuth via `Bearer` header
- ✅ `#[serde(rename_all = "camelCase")]` for Gemini API fields
- ✅ Eliminated unnecessary String allocation in model filtering

## Usage

```bash
# Login (opens browser, auto-captures callback)
golem login google

# Run with Gemini
golem --provider google
golem --provider google --model gemini-3.1-pro-preview

# REPL commands work too
golem> /login    # when running with --provider google
golem> /model    # lists Gemini models
```

Also supports `GEMINI_API_KEY` env var as fallback (no OAuth needed).

## Tests

213 total (31 new) — all passing, zero clippy warnings.